### PR TITLE
core dump (rte_malloc_get_socket_stats)

### DIFF
--- a/lib/librte_eal/common/malloc_heap.c
+++ b/lib/librte_eal/common/malloc_heap.c
@@ -188,7 +188,8 @@ malloc_heap_get_stats(const struct malloc_heap *heap,
 	socket_stats->free_count = 0;
 	socket_stats->heap_freesz_bytes = 0;
 	socket_stats->greatest_free_size = 0;
-
+	
+        rte_spinlock_lock(&heap->lock);
 	/* Iterate through free list */
 	for (idx = 0; idx < RTE_HEAP_NUM_FREELISTS; idx++) {
 		for (elem = LIST_FIRST(&heap->free_head[idx]);
@@ -200,6 +201,8 @@ malloc_heap_get_stats(const struct malloc_heap *heap,
 				socket_stats->greatest_free_size = elem->size;
 		}
 	}
+	rte_spinlock_unlock(&heap->lock);
+	
 	/* Get stats on overall heap and allocated memory on this heap */
 	socket_stats->heap_totalsz_bytes = heap->total_size;
 	socket_stats->heap_allocsz_bytes = (socket_stats->heap_totalsz_bytes -


### PR DESCRIPTION
Our program will be core dump every few months，dump point：
#0  0x00000000004a6be3 in malloc_heap_get_stats () 

cat /var/log/messages
Oct 24 02:50:58 xxxxxx kernel: traps: xxxx[193269] general protection ip:4a6be3 sp:7fffffffde98 error:0 in xxxx[400000+29f000]


The function rte_malloc_get_socket_stats calls malloc_heap_get_stats 
There is a lock in the operation list in malloc_heap_alloc, but there is no lock in the function malloc_heap_get_stats.
Because malloc_heap_get_stats uses a two-way linked list LIST_FIRST (&heap->free_head[idx])
It's not safe to traverse this list,
`	for (idx = 0; idx < RTE_HEAP_NUM_FREELISTS; idx++) {
		for (elem = LIST_FIRST(&heap->free_head[idx]);
			!!elem; elem = LIST_NEXT(elem, free_list))
		{
			socket_stats->free_count++;
			socket_stats->heap_freesz_bytes += elem->size;
			if (elem->size > socket_stats->greatest_free_size)
				socket_stats->greatest_free_size = elem->size;
		}
	}`
