### PR TITLE
net/bonding: fix bond mac when link down

### DIFF
--- a/drivers/net/bonding/rte_eth_bond_pmd.c
+++ b/drivers/net/bonding/rte_eth_bond_pmd.c
@@ -1625,7 +1625,7 @@ mac_address_slaves_update(struct rte_eth_dev *bonded_eth_dev)
 			if (internals->slaves[i].port_id ==
 					internals->current_primary_port) {
 				if (rte_eth_dev_default_mac_addr_set(
-						internals->primary_port,
+						internals->current_primary_port,
 						bonded_eth_dev->data->mac_addrs)) {
 					RTE_BOND_LOG(ERR, "Failed to update port Id %d MAC address",
 							internals->current_primary_port);
@@ -2726,6 +2726,8 @@ bond_ethdev_lsc_event_callback(uint16_t port_id, enum rte_eth_event_type type,
 			else
 				internals->current_primary_port = internals->primary_port;
 		}
+
+		mac_address_slaves_update(bonded_eth_dev);
 	}
 
 link_update:


### PR DESCRIPTION
We should always ensure bond mac address is updated to current primary port, which is the active slave, instead of primary port. Also mac_address_slaves_update is nessesary when switching current primary port due to link down.

Signed-off-by: Andrew Xu <ccxuy@126.com>