### PR TITLE
Allow C++ source code as well a C source in projects.

### DIFF
--- a/mk/internal/rte.compile-pre.mk
+++ b/mk/internal/rte.compile-pre.mk
@@ -8,8 +8,8 @@
 SRCS-all := $(SRCS-y) $(SRCS-n) $(SRCS-)
 
 # convert source to obj file
-src2obj = $(strip $(patsubst %.c,%.o,\
-	$(patsubst %.S,%_s.o,$(1))))
+src2obj = $(strip $(patsubst %.cpp,%.o,$(patsubst %.c,%.o,\
+	$(patsubst %.S,%_s.o,$(1)))))
 
 # add a dot in front of the file name
 dotfile = $(strip $(foreach f,$(1),\


### PR DESCRIPTION
Hi. We are working on a project with C and C++ source code. This change allows all the Makefile infrastructure to correctly work with C++ source files too.  Please include it.  Much thanks!