### PR TITLE
dpdk-devbind: print device index while listing the devices

### DIFF
--- a/usertools/dpdk-devbind.py
+++ b/usertools/dpdk-devbind.py
@@ -534,7 +534,9 @@ def display_devices(title, dev_list, extra_params=None):
                 strings.append("%s '%s'" % (dev["Slot"], dev["Device_str"]))
     # sort before printing, so that the entries appear in PCI order
     strings.sort()
-    print("\n".join(strings))  # print one per line
+    # add device index in front of each device
+    enum_dev_list = ['%2d' % index + ": " + device for index, device in enumerate(strings)]
+    print("\n".join(enum_dev_list))  # print one per line
 
 def show_device_status(devices_type, device_name):
     global dpdk_drivers


### PR DESCRIPTION
Add a device index in front of the PCI ID for easy counting

```
$ dpdk-devbind.py -s

Network devices using DPDK-compatible driver
============================================
 0: 0000:07:00.0 '82599ES 10-Gigabit SFI/SFP+ Network Connection 10fb' drv=igb_uio unused=ixgbe
 1: 0000:07:00.1 '82599ES 10-Gigabit SFI/SFP+ Network Connection 10fb' drv=igb_uio unused=ixgbe
 2: 0000:08:00.0 '82599ES 10-Gigabit SFI/SFP+ Network Connection 10fb' drv=igb_uio unused=ixgbe
 3: 0000:08:00.1 '82599ES 10-Gigabit SFI/SFP+ Network Connection 10fb' drv=igb_uio unused=ixgbe
 4: 0000:09:00.0 '82599ES 10-Gigabit SFI/SFP+ Network Connection 10fb' drv=igb_uio unused=ixgbe
 5: 0000:09:00.1 '82599ES 10-Gigabit SFI/SFP+ Network Connection 10fb' drv=igb_uio unused=ixgbe
 6: 0000:81:00.0 '82599ES 10-Gigabit SFI/SFP+ Network Connection 10fb' drv=igb_uio unused=ixgbe
 7: 0000:81:00.1 '82599ES 10-Gigabit SFI/SFP+ Network Connection 10fb' drv=igb_uio unused=ixgbe
 8: 0000:84:00.1 '82599ES 10-Gigabit SFI/SFP+ Network Connection 10fb' drv=igb_uio unused=ixgbe
 9: 0000:8a:00.0 '82599ES 10-Gigabit SFI/SFP+ Network Connection 10fb' drv=igb_uio unused=ixgbe
10: 0000:8a:00.1 '82599ES 10-Gigabit SFI/SFP+ Network Connection 10fb' drv=igb_uio unused=ixgbe
11: 0000:8c:00.0 '82599ES 10-Gigabit SFI/SFP+ Network Connection 10fb' drv=igb_uio unused=ixgbe
12: 0000:8c:00.1 '82599ES 10-Gigabit SFI/SFP+ Network Connection 10fb' drv=igb_uio unused=ixgbe
```