### PR TITLE
Update ixgbe_ethdev.c

### DIFF
--- a/drivers/net/ixgbe/ixgbe_ethdev.c
+++ b/drivers/net/ixgbe/ixgbe_ethdev.c
@@ -2613,11 +2613,11 @@ ixgbe_dev_start(struct rte_eth_dev *dev)
 		return -EINVAL;
 	}
 
-	/* Stop the link setup handler before resetting the HW. */
-	rte_eal_alarm_cancel(ixgbe_dev_setup_link_alarm_handler, dev);
-
 	/* disable uio/vfio intr/eventfd mapping */
 	rte_intr_disable(intr_handle);
+	
+	/* Stop the link setup handler before resetting the HW. */
+	rte_eal_alarm_cancel(ixgbe_dev_setup_link_alarm_handler, dev);
 
 	/* stop adapter */
 	hw->adapter_stopped = 0;
@@ -2879,10 +2879,10 @@ ixgbe_dev_stop(struct rte_eth_dev *dev)
 
 	PMD_INIT_FUNC_TRACE();
 
-	rte_eal_alarm_cancel(ixgbe_dev_setup_link_alarm_handler, dev);
-
 	/* disable interrupts */
 	ixgbe_disable_intr(hw);
+	
+	rte_eal_alarm_cancel(ixgbe_dev_setup_link_alarm_handler, dev);
 
 	/* reset the NIC */
 	ixgbe_pf_reset_hw(hw);


### PR DESCRIPTION
operation: Close the interrupt before alarm cancel
cause: 
thread1(such as control thread) : unplug the driver（such as uio unmap）
intr process thread: add the alarm process ( ixgbe_dev_setup_link_alarm_handler)

if the interrupt process add the alarm process ( ixgbe_dev_setup_link_alarm_handler) between the alarm cancel and ixgbe_disable_intr func, it will be success ,and the hw is null after(uio_unmap_resource),when the ixgbe_dev_setup_link_alarm_handler executes，it crashes