### PR TITLE
drivers/bus/pci/linux/pci.c:Fix multiple NICs address conflicts in 64K pagesize.

### DIFF
--- a/drivers/bus/pci/linux/pci.c
+++ b/drivers/bus/pci/linux/pci.c
@@ -201,6 +201,11 @@ pci_parse_sysfs_resource(const char *filename, struct rte_pci_device *dev)
 		if (flags & IORESOURCE_MEM) {
 			dev->mem_resource[i].phys_addr = phys_addr;
 			dev->mem_resource[i].len = end_addr - phys_addr + 1;
+			if (dev->mem_resource[i].len <
+				(unsigned int)getpagesize())
+
+				dev->mem_resource[i].len =
+					(unsigned int)getpagesize();
 			/* not mapped for now */
 			dev->mem_resource[i].addr = NULL;
 		}


### PR DESCRIPTION
An NIC address conflicts occur in 64K pagesize when using multiple NICs.With intel 82599,system will mmap 64K pagesize to NIC, but the dev->mem_resource[i].len is 16K, so it will conflicts when mmap the next NIC.After modified ,the problem can be solved, and DPDK works well. So please check if it can be modified like this.