### PR TITLE
change lspci output decode from ascii to utf-8

### DIFF
--- a/usertools/dpdk-devbind.py
+++ b/usertools/dpdk-devbind.py
@@ -208,7 +208,7 @@ def get_pci_device_details(dev_id, probe_lspci):
         for line in extra_info:
             if len(line) == 0:
                 continue
-            name, value = line.decode().split("\t", 1)
+            name, value = line.decode('utf-8').split("\t", 1)
             name = name.strip(":") + "_str"
             device[name] = value
     # check for a unix interface name
@@ -254,7 +254,7 @@ def get_device_details(devices_type):
             # Clear previous device's data
             dev = {}
         else:
-            name, value = dev_line.decode().split("\t", 1)
+            name, value = dev_line.decode('utf-8').split("\t", 1)
             value_list = value.rsplit(' ', 1)
             if len(value_list) > 1:
                 # String stored in <name>_str


### PR DESCRIPTION
lspci output may contain utf-8 character, and this cause  dpdk-devbind to fail. For example:
 
root# lspci -vmmks 0000:af:00.0
Slot:   af:00.0
Class:  Ethernet controller
Vendor: Mellanox Technologies
Device: MT27800 Family [ConnectX-5]
SVendor:        Mellanox Technologies
SDevice:        ConnectX®-5 EN network interface card, 100GbE single-port QSFP28, PCIe3.0 x16, tall bracket; MCX515A-CCAT
Driver: mlx5_core
lspci: Unable to load libkmod resources: error -12
NUMANode:       1

root# dpdk-devbind -s
lspci: Unable to load libkmod resources: error -12
Traceback (most recent call last):
  File "/usr/local/bin/dpdk-devbind", line 741, in <module>
    main()
  File "/usr/local/bin/dpdk-devbind", line 731, in main
    get_device_details(network_devices)
  File "/usr/local/bin/dpdk-devbind", line 257, in get_device_details
    name, value = dev_line.decode().split("\t", 1)
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 17: ordinal not in range(128)

change to str decode from the default ascii to 'utf-8' shall solve this issue.
