### PR TITLE
Moving definitions of reorder buffer from .c to .h file

### DIFF
--- a/lib/librte_reorder/rte_reorder.c
+++ b/lib/librte_reorder/rte_reorder.c
@@ -2,8 +2,6 @@
  * Copyright(c) 2010-2014 Intel Corporation
  */
 
-#include <inttypes.h>
-#include <string.h>
 
 #include <rte_string_fns.h>
 #include <rte_log.h>
@@ -22,31 +20,9 @@ static struct rte_tailq_elem rte_reorder_tailq = {
 };
 EAL_REGISTER_TAILQ(rte_reorder_tailq)
 
-#define NO_FLAGS 0
-#define RTE_REORDER_PREFIX "RO_"
-#define RTE_REORDER_NAMESIZE 32
-
 /* Macros for printing using RTE_LOG */
 #define RTE_LOGTYPE_REORDER	RTE_LOGTYPE_USER1
 
-/* A generic circular buffer */
-struct cir_buffer {
-	unsigned int size;   /**< Number of entries that can be stored */
-	unsigned int mask;   /**< [buffer_size - 1]: used for wrap-around */
-	unsigned int head;   /**< insertion point in buffer */
-	unsigned int tail;   /**< extraction point in buffer */
-	struct rte_mbuf **entries;
-} __rte_cache_aligned;
-
-/* The reorder buffer data structure itself */
-struct rte_reorder_buffer {
-	char name[RTE_REORDER_NAMESIZE];
-	uint32_t min_seqn;  /**< Lowest seq. number that can be in the buffer */
-	unsigned int memsize; /**< memory area size of reorder buffer */
-	struct cir_buffer ready_buf; /**< temp buffer for dequeued entries */
-	struct cir_buffer order_buf; /**< buffer used to reorder entries */
-	int is_initialized;
-} __rte_cache_aligned;
 
 static void
 rte_reorder_free_mbufs(struct rte_reorder_buffer *b);

--- a/lib/librte_reorder/rte_reorder.h
+++ b/lib/librte_reorder/rte_reorder.h
@@ -15,13 +15,43 @@
  *
  */
 
+#include <inttypes.h>
+#include <string.h>
+
 #include <rte_mbuf.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-struct rte_reorder_buffer;
+#define NO_FLAGS 0
+#define RTE_REORDER_PREFIX "RO_"
+#define RTE_REORDER_NAMESIZE 32
+
+/**
+ * @brief A generic circular buffer 
+ */
+struct cir_buffer {
+	unsigned int size;   /**< Number of entries that can be stored */
+	unsigned int mask;   /**< [buffer_size - 1]: used for wrap-around */
+	unsigned int head;   /**< insertion point in buffer */
+	unsigned int tail;   /**< extraction point in buffer */
+	struct rte_mbuf **entries;
+} __rte_cache_aligned;
+
+
+/**
+ * @brief The reorder buffer data structure itself 
+ */
+struct rte_reorder_buffer {
+	char name[RTE_REORDER_NAMESIZE];
+	uint32_t min_seqn;  /**< Lowest seq. number that can be in the buffer */
+	unsigned int memsize; /**< memory area size of reorder buffer */
+	struct cir_buffer ready_buf; /**< temp buffer for dequeued entries */
+	struct cir_buffer order_buf; /**< buffer used to reorder entries */
+	int is_initialized;
+} __rte_cache_aligned;
+
 
 /**
  * Create a new reorder buffer instance


### PR DESCRIPTION
Moving definitions of structure to header files would help in accessing structure members from outside(c file), thus enabling better use cases. 
1. Like initializing min_seqn field on creation/initialization of buffer. 
2. Moving head of order_buf/reorder_buf manually. suppose there is hole in window like 1,3,4,5.while performing drain, 3,4,5 wont be drained till 2 is received. on such cases moving head would in kind of a force drain.