### PR TITLE
net/kni: set packet input port in eth_kni_rx()

### DIFF
--- a/drivers/net/kni/rte_eth_kni.c
+++ b/drivers/net/kni/rte_eth_kni.c
@@ -47,6 +47,7 @@ struct pmd_queue {
 
 struct pmd_internals {
 	struct rte_kni *kni;
+	uint16_t port_id;
 	int is_kni_started;
 
 	pthread_t thread;
@@ -78,9 +79,13 @@ eth_kni_rx(void *q, struct rte_mbuf **bufs, uint16_t nb_bufs)
 	struct pmd_queue *kni_q = q;
 	struct rte_kni *kni = kni_q->internals->kni;
 	uint16_t nb_pkts;
+	int i;
 
 	nb_pkts = rte_kni_rx_burst(kni, bufs, nb_bufs);
-
+	for (i = 0; i < nb_pkts; i++) {
+		bufs[i]->port = kni_q->internals->port_id;
+	}
+	
 	kni_q->rx.pkts += nb_pkts;
 
 	return nb_pkts;
@@ -372,6 +377,7 @@ eth_kni_create(struct rte_vdev_device *vdev,
 		return NULL;
 
 	internals = eth_dev->data->dev_private;
+	internals->port_id = eth_dev->data->port_id;
 	data = eth_dev->data;
 	data->nb_rx_queues = 1;
 	data->nb_tx_queues = 1;


### PR DESCRIPTION
Store port_id in pmd_internals when eth kni device is created.
Then set packet port of rte_mbuf in function eth_kni_rx.

Signed-off-by: Jecky Pei <jeckypei@163.com>