### PR TITLE
update meson.build: arm neoverse-n1 flags

### DIFF
--- a/config/arm/meson.build
+++ b/config/arm/meson.build
@@ -86,6 +86,12 @@ flags_octeontx2_extra = [
 	['RTE_ARM_FEATURE_ATOMICS', true],
 	['RTE_EAL_IGB_UIO', false],
 	['RTE_USE_C11_MEM_MODEL', true]]
+	
+flags_n1generic_extra = [
+	['RTE_MACHINE', '"neoverse-n1generic"'],
+	['RTE_MAX_NUMA_NODES', 1],
+	['RTE_MAX_LCORE', 64],
+	{'RTE_MAX_MEM_MB', 1048576]]
 
 machine_args_generic = [
 	['default', ['-march=armv8-a+crc']],
@@ -97,7 +103,7 @@ machine_args_generic = [
 	['0xd09', ['-mcpu=cortex-a73']],
 	['0xd0a', ['-mcpu=cortex-a75']],
 	['0xd0b', ['-mcpu=cortex-a76']],
-	['0xd0c', ['-march=armv8.2-a+crc+crypto', '-mcpu=neoverse-n1'], flags_n1sdp_extra]]
+	['0xd0c', ['-march=armv8.2-a+crypto+rcpc', '-mcpu=neoverse-n1'], flags_n1generic_extra]]
 
 machine_args_cavium = [
 	['default', ['-march=armv8-a+crc+crypto','-mcpu=thunderx']],

--- a/config/arm/meson.build
+++ b/config/arm/meson.build
@@ -91,7 +91,7 @@ flags_n1generic_extra = [
 	['RTE_MACHINE', '"neoverse-n1generic"'],
 	['RTE_MAX_NUMA_NODES', 1],
 	['RTE_MAX_LCORE', 64],
-	{'RTE_MAX_MEM_MB', 1048576]]
+	['RTE_MAX_MEM_MB', 1048576]]
 
 machine_args_generic = [
 	['default', ['-march=armv8-a+crc']],


### PR DESCRIPTION
1. remove +crc as that is default when setting armv8.2
2. add rcpc
3. Increase support memory space
4. remove 4 LCORE limit
5. decouple n1dsp from n1generic.    the 0xd0c is a generic setting for neoverse-n1 and not specific to n1dsp platform