### PR TITLE
app: only build test apps if the 'tests' option is set

### DIFF
--- a/app/meson.build
+++ b/app/meson.build
@@ -8,6 +8,10 @@ endif
 apps = [
 	'pdump',
 	'proc-info',
+]
+
+if get_option('tests')
+apps += [
 	'test-acl',
 	'test-bbdev',
 	'test-cmdline',
@@ -19,7 +23,9 @@ apps = [
 	'test-pipeline',
 	'test-pmd',
 	'test-regex',
-	'test-sad']
+	'test-sad',
+]
+endif
 
 # for BSD only
 lib_execinfo = cc.find_library('execinfo', required: false)


### PR DESCRIPTION
Save time and space by not compiling test apps if they are not specifically requested.