### PR TITLE
doc: fix and add some message

### DIFF
--- a/doc/guides/nics/nfp.rst
+++ b/doc/guides/nics/nfp.rst
@@ -117,15 +117,19 @@ although once they are created, DPDK apps should be able to use them as normal
 PCI ports.
 
 NFP ports belonging to same PF can be seen inside PMD initialization with a
-suffix added to the PCI ID: wwww:xx:yy.z_port_n. For example, a PF with PCI ID
+suffix added to the PCI ID: wwww:xx:yy.z_portn. For example, a PF with PCI ID
 0000:03:00.0 and four ports is seen by the PMD code as:
 
    .. code-block:: console
 
-      0000:03:00.0_port_0
-      0000:03:00.0_port_1
-      0000:03:00.0_port_2
-      0000:03:00.0_port_3
+      0000:03:00.0_port0
+      0000:03:00.0_port1
+      0000:03:00.0_port2
+      0000:03:00.0_port3
+
+Some dpdk applications can choose to use the MAC address to identify ports,
+OVS-DPDK is one such example, please refer to:
+https://docs.openvswitch.org/en/latest/howto/dpdk/
 
    .. Note::
 


### PR DESCRIPTION
1. Fixup the suffix of the PCI ID to consistent with the code: from wwww:xx:yy.z_port_n to wwww:xx:yy.z_portn
2. Add specification of using Mac address to identify port.

Signed-off-by: Chaoyong.He <chaoyong.he@corigine.com>