### PR TITLE
fix l2fwd --no-mac-updating not working issue

### DIFF
--- a/examples/l2fwd/main.c
+++ b/examples/l2fwd/main.c
@@ -492,7 +492,10 @@ l2fwd_parse_args(int argc, char **argv)
 			timer_period = timer_secs;
 			break;
 
-		/* long options */
+		/* no-mac-updating */
+		case 0:
+			break;
+
 		case CMD_LINE_OPT_PORTMAP_NUM:
 			ret = l2fwd_parse_port_pair_config(optarg);
 			if (ret) {


### PR DESCRIPTION
The original disable mac updating codes were removed by mistake. Need to get it back.