### PR TITLE
ppc64le: fix build with Clang and without glibc

### DIFF
--- a/lib/librte_eal/ppc/include/rte_altivec.h
+++ b/lib/librte_eal/ppc/include/rte_altivec.h
@@ -7,6 +7,9 @@
 #define _RTE_ALTIVEC_H_
 
 /* To include altivec.h, GCC version must be >= 4.8 */
+#ifdef __clang__
+#define vector __vector
+#endif
 #include <altivec.h>
 
 /*

--- a/lib/librte_eal/ppc/include/rte_cycles.h
+++ b/lib/librte_eal/ppc/include/rte_cycles.h
@@ -10,7 +10,13 @@
 extern "C" {
 #endif
 
+#ifdef linux
+#include <features.h>
+#endif
+
+#ifdef __GLIBC__
 #include <sys/platform/ppc.h>
+#endif
 
 #include "generic/rte_cycles.h"
 
@@ -26,7 +32,13 @@ extern "C" {
 static inline uint64_t
 rte_rdtsc(void)
 {
+#ifdef __GLIBC__
 	return __ppc_get_timebase();
+#else
+	uint64_t __tb;
+	__asm__ volatile ("mfspr %0, 268" : "=r" (__tb));
+	return __tb;
+#endif
 }
 
 static inline uint64_t

--- a/lib/librte_eal/ppc/rte_cycles.c
+++ b/lib/librte_eal/ppc/rte_cycles.c
@@ -2,12 +2,24 @@
  * Copyright (C) IBM Corporation 2019.
  */
 
+#ifdef linux
+#include <features.h>
+#endif
+
+#ifdef __GLIBC__
 #include <sys/platform/ppc.h>
+#endif
 
 #include "eal_private.h"
 
 uint64_t
 get_tsc_freq_arch(void)
 {
+#ifdef __GLIBC__
 	return __ppc_get_timebase_freq();
+#else
+	uint64_t __tb;
+	__asm__ volatile ("mfspr %0, 268" : "=r" (__tb));
+	return __tb;
+#endif
 }


### PR DESCRIPTION
There are couple of issues when building with Clang:
1. vector is a keyword and should not be used in code. I undefined it,
but it would probably be better to just change the variable name.
2. vector long is deprecated by Clang and should not be used. I switched
here to vector int.
3. Additionally, sys/platform/ppc.h is glibc-dependant and is not available
in other libc's. Use the portable method of reading TBR when glibc is not used.
Taken from https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/powerpc/sys/platform/ppc.h

This was tested with Clang 11.0.1 on FreeBSD 13.0-RC1 on POWER9 box.