### PR TITLE
hash/rte_hash: fix the document of rte_hash

### DIFF
--- a/lib/hash/rte_hash.h
+++ b/lib/hash/rte_hash.h
@@ -448,7 +448,7 @@ rte_hash_free_key_with_position(const struct rte_hash *h,
  * @param data
  *   Output with pointer to data returned from the hash table.
  * @return
- *   - A positive value that can be used by the caller as an offset into an
+ *   - A non-negative value that can be used by the caller as an offset into an
  *     array of user data. This value is unique for this key, and is the same
  *     value that was returned when the key was added.
  *   - -EINVAL if the parameters are invalid.


### PR DESCRIPTION
The rte_hash_lookup_data function can return ZERO which is not a positive value.

```
// code to print the return vlaue
ret = rte_hash_lookup_data(flow_hash_table, key, (void **) &data);
zlog_debug(zc, "packet(%u)(%d): %s", m->pkt_len,ret, pkt_info);

// the log of my code
//worker | DEBUG [packet_processing.c:90] packet(74)(-2):  - src_ip=108.61.180.247:33080 - dst_ip=125.209.234.39:443 - queue=0x0
//worker | DEBUG [packet_processing.c:98] success add a flow to flow hash table
//worker | DEBUG [packet_processing.c:90] packet(74)(-2):  - src_ip=108.61.180.247:33082 - dst_ip=125.209.234.39:443 - queue=0x0
//worker | DEBUG [packet_processing.c:98] success add a flow to flow hash table
//worker | DEBUG [packet_processing.c:90] packet(74)(-2):  - src_ip=125.209.234.39:443 - dst_ip=108.61.180.247:33080 - queue=0x0
//worker | DEBUG [packet_processing.c:98] success add a flow to flow hash table
//worker | DEBUG [packet_processing.c:90] packet(66)(0):  - src_ip=108.61.180.247:33080 - dst_ip=125.209.234.39:443 - queue=0x0
//worker | ERROR [packet_processing.c:105] unhandled error occur
```