### PR TITLE
Correcting incorrect memory zeroing

### DIFF
--- a/drivers/net/softnic/rte_eth_softnic_meter.c
+++ b/drivers/net/softnic/rte_eth_softnic_meter.c
@@ -791,7 +791,7 @@ mtr_stats_convert(struct pmd_internals *p,
 {
 	struct softnic_mtr_meter_policy *mp;
 
-	memset(&out, 0, sizeof(out));
+	memset(out, 0, sizeof(*out));
 	*out_mask = 0;
 
 	/* Meter policy must exist */


### PR DESCRIPTION
Hello. Memory will be cleared incorrectly when working with a pointer. The pointer is zeroed, not the structure it points to. Working with null pointers is not possible. An emergency exit from the program will occur. These changes correct this situation.