### PR TITLE
Adds  include inttypes.h

### DIFF
--- a/lib/rcu/rte_rcu_qsbr.h
+++ b/lib/rcu/rte_rcu_qsbr.h
@@ -32,6 +32,7 @@ extern "C" {
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdint.h>
+#include <inttypes.h>
 #include <rte_common.h>
 #include <rte_debug.h>
 #include <rte_atomic.h>


### PR DESCRIPTION
Without this type def we get a compiler error:
error: expected ')' before 'PRId64' 
Similar to the errors here: http://mails.dpdk.org/archives/test-report/2022-February/256520.html

This is when being compiled on Cent7 using gcc version 4.8.5