### PR TITLE
net/ice: null field checks in ice_{r,t}x_queue_release

### DIFF
--- a/drivers/net/ice/ice_rxtx.c
+++ b/drivers/net/ice/ice_rxtx.c
@@ -1197,7 +1197,8 @@ ice_rx_queue_release(void *rxq)
 		return;
 	}
 
-	q->rx_rel_mbufs(q);
+	if (q->rx_rel_mbufs != NULL)
+		q->rx_rel_mbufs(q);
 	rte_free(q->sw_ring);
 	rte_memzone_free(q->mz);
 	rte_free(q);
@@ -1407,7 +1408,8 @@ ice_tx_queue_release(void *txq)
 		return;
 	}
 
-	q->tx_rel_mbufs(q);
+	if (q->tx_rel_mbufs != NULL)
+		q->tx_rel_mbufs(q);
 	rte_free(q->sw_ring);
 	rte_memzone_free(q->mz);
 	rte_free(q);


### PR DESCRIPTION
In case rte_eth_dma_zone_reserve fails in ice_tx_queue_setup
ice_tx_queue_release is called on 0 allocated but not initialized
txq struct.
This may happen on ENOMEM condition, size exhaustion of
memconfig->memzones array as well as some others.