### PR TITLE
Fix bugs of ip_reassembly

### DIFF
--- a/examples/ip_reassembly/main.c
+++ b/examples/ip_reassembly/main.c
@@ -1067,7 +1067,7 @@ main(int argc, char **argv)
 			qconf = &lcore_queue_conf[rx_lcore_id];
 		}
 
-		socket = rte_lcore_to_socket_id(portid);
+		socket = rte_lcore_to_socket_id(rx_lcore_id);
 		if (socket == SOCKET_ID_ANY)
 			socket = 0;
 


### PR DESCRIPTION
the parameter of rte_lcore_to_socket_id function is core_id, not portid.