### PR TITLE
ACL trie splitting

### DIFF
--- a/app/test-acl/test-acl.sh
+++ b/app/test-acl/test-acl.sh
@@ -17,7 +17,7 @@
 # <proto>'/'<mask>
 # trace record format:
 # <src_ip_addr><space><dst_ip_addr><space> \
-# <src_port><space<dst_port><space><proto>...<rule_id>
+# <src_port><space><dst_port><space><proto>...<rule_id>
 #
 # As an example:
 # /bin/bash app/test-acl/test-acl.sh build/app/dpdk-test-acl \

--- a/lib/acl/acl_bld.c
+++ b/lib/acl/acl_bld.c
@@ -946,7 +946,7 @@ build_trie(struct acl_build_context *context, struct rte_acl_build_rule *head,
 	struct rte_acl_build_rule **last, uint32_t *count)
 {
 	uint32_t n, m;
-	int field_index, node_count;
+	int field_index;
 	struct rte_acl_node *trie;
 	struct rte_acl_build_rule *prev, *rule;
 	struct rte_acl_node *end, *merge, *root, *end_prev;
@@ -1048,15 +1048,13 @@ build_trie(struct acl_build_context *context, struct rte_acl_build_rule *head,
 			}
 		}
 
-		node_count = context->num_nodes;
 		(*count)++;
 
 		/* merge this rule into the trie */
 		if (acl_merge_trie(context, trie, root, 0, NULL))
 			return NULL;
 
-		node_count = context->num_nodes - node_count;
-		if (node_count > context->cur_node_max) {
+		if (context->num_nodes > (context->cur_node_max * context->num_tries)) {
 			*last = prev;
 			return trie;
 		}
@@ -1368,6 +1366,7 @@ acl_build_tries(struct acl_build_context *context,
 	for (n = 0;; n = num_tries) {
 
 		num_tries = n + 1;
+		context->num_tries = num_tries;
 
 		last = build_one_trie(context, rule_sets, n, context->node_max);
 		if (context->bld_tries[n].trie == NULL) {
@@ -1411,8 +1410,6 @@ acl_build_tries(struct acl_build_context *context,
 		}
 
 	}
-
-	context->num_tries = num_tries;
 	return 0;
 }
 


### PR DESCRIPTION
## Problem
I was trying out the test-acl example on some large input files (> 10k ACL rules) to do a performance comparison, but no matter how large the input, it seems to always build 1 trie. 

If I understand correctly, it is supposed to split when there are 2048 nodes (this macro #define NODE_MIN 0x800 in `acl_bld.c:20`) , but when I stepped through with a debugger the `node_count` is negative, so `node_count > context->cur_node_max` never actually runs, so all the nodes created from the rules end up being in one trie.
![image](https://user-images.githubusercontent.com/7380279/187782786-bb923a55-db08-4b9f-9833-0ff4b3ece8ba.png)

This is the specific command I used to run test-acl.sh:
```bash
/bin/bash app/test-acl/test-acl.sh build/app/dpdk-test-acl app/test-acl/input scalar 32
```
I have also attached the rule/trace files which I modified to have 2k ACL rules  (they are from app/test-acl/input/)
[acl1v4_5_rule.txt](https://github.com/DPDK/dpdk/files/9465047/acl1v4_5_rule.txt)
[acl1v4_5_trace.txt](https://github.com/DPDK/dpdk/files/9465001/acl1v4_5_trace.txt)

## Attempted Fix
In this PR I have changed the condition to `context->num_nodes > (context->cur_node_max * context->num_tries)` and the outer loop to update `context->num_tries`.  Using the same rules file, this time it generated 10k nodes and split into 5 tries as shown below, which is the expected behavior I think.
![image](https://user-images.githubusercontent.com/7380279/187781356-c6654003-8858-48a0-b731-b0baaaf048a9.png)


