### PR TITLE
ICE driver EEPROM bug fix

### DIFF
--- a/drivers/net/ice/ice_ethdev.c
+++ b/drivers/net/ice/ice_ethdev.c
@@ -5129,7 +5129,7 @@ ice_get_module_eeprom(struct rte_eth_dev *dev,
 			}
 
 			/* Make sure we have enough room for the new block */
-			if ((i + SFF_READ_BLOCK_SIZE) < info->length)
+			if ((i + SFF_READ_BLOCK_SIZE) <= info->length)
 				memcpy(data + i, value, SFF_READ_BLOCK_SIZE);
 		}
 	}


### PR DESCRIPTION
Fix issue with final word being dropped when retrieving module EEPROM data for ICE driver.

Take for simplicity the case when `info->offset` is zero and `info->len` is equal to `SFF_READ_BLOCK_SIZE`. In this case, memcpy would not be called despite there presumably being room in the buffer (as we have requested 8 bytes of data and the memcpy would write precisely 8 bytes). The same edge case will be hit on the final iteration of the for loop whenever a multiple of 8 bytes is requested, as the final word will not be written to the data buffer.