### PR TITLE
Clarify the lifetime of the return value of rte_mem_virt2iova

### DIFF
--- a/lib/eal/linux/eal_memory.c
+++ b/lib/eal/linux/eal_memory.c
@@ -155,6 +155,11 @@ rte_mem_virt2iova(const void *virtaddr)
 /*
  * For each hugepage in hugepg_tbl, fill the physaddr value. We find
  * it by browsing the /proc/self/pagemap special file.
+ *
+ * NOTE: Unless a kernel component (such as VFIO_NOIOMMU) locks the memory
+ * in place, the kernel may move the memory at any time (kcompactd, autonuma,
+ * etc etc) so one should only rely on this address being a constant in the
+ * general case.
  */
 static int
 find_physaddrs(struct hugepage_file *hugepg_tbl, struct hugepage_info *hpi)


### PR DESCRIPTION
The Linux kernel will move memory around (changing physical address while keeping the virtual address constant) for various uses. These include compaction, autonuma, defragmentation (for future hugetlb allocations) and many more.

Because of this, one cannot depend on the physical address of any mapping to be a constant, unless a specific kernel component has pinned the physical address in place. VFIO_NOIOMMU is an example of a kernel component that does this.

Note that "mlock()" does NOT do this. mlock() guarantees that the memory will not be swapped out (hard page fault) but the kernel is allowed, and will, move memory around for defragmentation. Just using hugetlbfs is also equally not sufficient for the same reason.