### PR TITLE
gpu/cuda: Add missing stdlib include

### DIFF
--- a/drivers/gpu/cuda/gdrcopy.c
+++ b/drivers/gpu/cuda/gdrcopy.c
@@ -2,6 +2,8 @@
  * Copyright (c) 2022 NVIDIA Corporation & Affiliates
  */
 
+#include <stdlib.h>
+
 #include "common.h"
 
 #ifdef DRIVERS_GPU_CUDA_GDRCOPY_H


### PR DESCRIPTION
getenv needs stdlib.h to be included. WIthout the include, the compiler on our system (Rocky 8.7) assumes the function to return an int and truncates the pointer, which causes a DPDK application to crash during initialization.

Bugzilla ID: 1133

Fixes: 24c77594e08f ("gpu/cuda: map GPU memory with GDRCopy")

