### PR TITLE
Swap the display order of MAX_PORTS and cnt_ports

### DIFF
--- a/examples/ethtool/ethtool-app/main.c
+++ b/examples/ethtool/ethtool-app/main.c
@@ -289,7 +289,7 @@ int main(int argc, char **argv)
 		rte_exit(EXIT_FAILURE, "No available NIC ports!\n");
 	if (cnt_ports > MAX_PORTS) {
 		printf("Info: Using only %i of %i ports\n",
-			cnt_ports, MAX_PORTS
+			MAX_PORTS, cnt_ports
 			);
 		cnt_ports = MAX_PORTS;
 	}


### PR DESCRIPTION
I think the meaning of Info here is that when there are too many ports, only MAX_PORTS ports can be used.