### PR TITLE
examples/ipsec-secgw: fix bug of rte_eth_add_rx_callback failure in single lcore scenario

### DIFF
--- a/drivers/crypto/openssl/rte_openssl_pmd.c
+++ b/drivers/crypto/openssl/rte_openssl_pmd.c
@@ -241,6 +241,9 @@ get_cipher_algo(enum rte_crypto_cipher_algorithm sess_algo, size_t keylen,
 				res = -EINVAL;
 			}
 			break;
+		case RTE_CRYPTO_CIPHER_SM4_CBC:
+			*algo = EVP_sm4_cbc();
+			break;
 		default:
 			res = -EINVAL;
 			break;
@@ -484,6 +487,7 @@ openssl_set_session_cipher_parameters(struct openssl_session *sess,
 	case RTE_CRYPTO_CIPHER_3DES_CBC:
 	case RTE_CRYPTO_CIPHER_AES_CBC:
 	case RTE_CRYPTO_CIPHER_AES_CTR:
+	case RTE_CRYPTO_CIPHER_SM4_CBC:
 		sess->cipher.mode = OPENSSL_CIPHER_LIB;
 		sess->cipher.algo = xform->cipher.algo;
 		sess->cipher.ctx = EVP_CIPHER_CTX_new();

--- a/drivers/crypto/openssl/rte_openssl_pmd_ops.c
+++ b/drivers/crypto/openssl/rte_openssl_pmd_ops.c
@@ -610,7 +610,26 @@ static const struct rte_cryptodev_capabilities openssl_pmd_capabilities[] = {
 		}
 		}
 	},
-
+	{	/* SM4 CBC */
+		.op = RTE_CRYPTO_OP_TYPE_SYMMETRIC,
+		{.sym = {
+			.xform_type = RTE_CRYPTO_SYM_XFORM_CIPHER,
+			{.cipher = {
+				.algo = RTE_CRYPTO_CIPHER_SM4_CBC,
+				.block_size = 16,
+				.key_size = {
+					.min = 16,
+					.max = 16,
+					.increment = 0
+				},
+				.iv_size = {
+					.min = 16,
+					.max = 16,
+					.increment = 0
+				}
+			}, }
+		}, }
+	},
 	RTE_CRYPTODEV_END_OF_CAPABILITIES_LIST()
 };
 

--- a/examples/ipsec-secgw/esp.c
+++ b/examples/ipsec-secgw/esp.c
@@ -103,6 +103,7 @@ esp_inbound(struct rte_mbuf *m, struct ipsec_sa *sa,
 		case RTE_CRYPTO_CIPHER_DES_CBC:
 		case RTE_CRYPTO_CIPHER_3DES_CBC:
 		case RTE_CRYPTO_CIPHER_AES_CBC:
+		case RTE_CRYPTO_CIPHER_SM4_CBC:
 			/* Copy IV at the end of crypto operation */
 			rte_memcpy(iv_ptr, iv, sa->iv_len);
 			break;
@@ -341,6 +342,7 @@ esp_outbound(struct rte_mbuf *m, struct ipsec_sa *sa,
 		case RTE_CRYPTO_CIPHER_DES_CBC:
 		case RTE_CRYPTO_CIPHER_3DES_CBC:
 		case RTE_CRYPTO_CIPHER_AES_CBC:
+		case RTE_CRYPTO_CIPHER_SM4_CBC:
 			memset(iv, 0, sa->iv_len);
 			break;
 		case RTE_CRYPTO_CIPHER_AES_CTR:
@@ -405,6 +407,7 @@ esp_outbound(struct rte_mbuf *m, struct ipsec_sa *sa,
 		case RTE_CRYPTO_CIPHER_DES_CBC:
 		case RTE_CRYPTO_CIPHER_3DES_CBC:
 		case RTE_CRYPTO_CIPHER_AES_CBC:
+		case RTE_CRYPTO_CIPHER_SM4_CBC:
 			sym_cop->cipher.data.offset = ip_hdr_len +
 				sizeof(struct rte_esp_hdr);
 			sym_cop->cipher.data.length = pad_payload_len + sa->iv_len;

--- a/examples/ipsec-secgw/ipsec-secgw.c
+++ b/examples/ipsec-secgw/ipsec-secgw.c
@@ -236,15 +236,7 @@ struct lcore_conf lcore_conf[RTE_MAX_LCORE];
 
 static struct rte_eth_conf port_conf = {
 	.rxmode = {
-		.mq_mode	= RTE_ETH_MQ_RX_RSS,
-		.offloads = RTE_ETH_RX_OFFLOAD_CHECKSUM,
-	},
-	.rx_adv_conf = {
-		.rss_conf = {
-			.rss_key = NULL,
-			.rss_hf = RTE_ETH_RSS_IP | RTE_ETH_RSS_UDP |
-				RTE_ETH_RSS_TCP | RTE_ETH_RSS_SCTP,
-		},
+		.mq_mode	= RTE_ETH_MQ_RX_NONE,
 	},
 	.txmode = {
 		.mq_mode = RTE_ETH_MQ_TX_NONE,

--- a/examples/ipsec-secgw/ipsec-secgw.c
+++ b/examples/ipsec-secgw/ipsec-secgw.c
@@ -2094,10 +2094,10 @@ port_init(uint16_t portid, uint64_t req_rx_offloads, uint64_t req_tx_offloads,
 
 			/* Register Rx callback if ptypes are not supported */
 			if (!ptype_supported &&
-			    !rte_eth_add_rx_callback(portid, queue,
+			    !rte_eth_add_rx_callback(portid, rx_queueid,
 						     parse_ptype_cb, NULL)) {
 				printf("Failed to add rx callback: port=%d, "
-				       "queue=%d\n", portid, queue);
+				       "queue=%d\n", portid, rx_queueid);
 			}
 
 

--- a/examples/ipsec-secgw/sa.c
+++ b/examples/ipsec-secgw/sa.c
@@ -128,7 +128,14 @@ const struct supported_cipher_algo cipher_algos[] = {
 		.iv_len = 8,
 		.block_size = 8,
 		.key_len = 8
-	}
+	},
+	{
+		.keyword = "sm4-cbc",
+		.algo = RTE_CRYPTO_CIPHER_SM4_CBC,
+		.iv_len = 16,
+		.block_size = 16,
+		.key_len = 16
+	},
 };
 
 const struct supported_auth_algo auth_algos[] = {
@@ -502,7 +509,8 @@ parse_sa_tokens(char **tokens, uint32_t n_tokens,
 				return;
 
 			if (algo->algo == RTE_CRYPTO_CIPHER_AES_CBC ||
-				algo->algo == RTE_CRYPTO_CIPHER_3DES_CBC)
+				algo->algo == RTE_CRYPTO_CIPHER_3DES_CBC ||
+				algo->algo == RTE_CRYPTO_CIPHER_SM4_CBC)
 				rule->salt = (uint32_t)rte_rand();
 
 			if (algo->algo == RTE_CRYPTO_CIPHER_AES_CTR) {
@@ -1330,6 +1338,7 @@ sa_add_rules(struct sa_ctx *sa_ctx, const struct ipsec_sa entries[],
 			case RTE_CRYPTO_CIPHER_DES_CBC:
 			case RTE_CRYPTO_CIPHER_3DES_CBC:
 			case RTE_CRYPTO_CIPHER_AES_CBC:
+			case RTE_CRYPTO_CIPHER_SM4_CBC:
 				iv_length = sa->iv_len;
 				break;
 			case RTE_CRYPTO_CIPHER_AES_CTR:


### PR DESCRIPTION
In the scenario of multiple ports and single lcore, rte_eth_add_rx_callback will fail because the queueid here is used incorrectly and rx_queueid should be used.