### PR TITLE
examples/ipsec-secgw: fix bug of rte_eth_add_rx_callback failure in single lcore scenario

### DIFF
--- a/examples/ipsec-secgw/ipsec-secgw.c
+++ b/examples/ipsec-secgw/ipsec-secgw.c
@@ -2094,10 +2094,10 @@ port_init(uint16_t portid, uint64_t req_rx_offloads, uint64_t req_tx_offloads,
 
 			/* Register Rx callback if ptypes are not supported */
 			if (!ptype_supported &&
-			    !rte_eth_add_rx_callback(portid, queue,
+			    !rte_eth_add_rx_callback(portid, rx_queueid,
 						     parse_ptype_cb, NULL)) {
 				printf("Failed to add rx callback: port=%d, "
-				       "queue=%d\n", portid, queue);
+				       "queue=%d\n", portid, rx_queueid);
 			}
 
 


### PR DESCRIPTION
In the scenario of multiple ports and single lcore, rte_eth_add_rx_callback will fail because the queueid here is used incorrectly and rx_queueid should be used.