### PR TITLE
ci: remove ipsec-mb package install

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,7 +106,7 @@ jobs:
       run: sudo apt update || true
     - name: Install packages
       run: sudo apt install -y ccache libarchive-dev libbsd-dev libbpf-dev
-        libfdt-dev libibverbs-dev libipsec-mb-dev libisal-dev libjansson-dev
+        libfdt-dev libibverbs-dev libisal-dev libjansson-dev
         libnuma-dev libpcap-dev libssl-dev ninja-build pkg-config python3-pip
         python3-pyelftools python3-setuptools python3-wheel zlib1g-dev
     - name: Install libabigail build dependencies if no cache is available
@@ -187,7 +187,7 @@ jobs:
       run: docker exec -i dpdk dnf update -y
     - name: Install packages
       if: steps.image_cache.outputs.cache-hit != 'true'
-      run: docker exec -i dpdk dnf install -y ccache intel-ipsec-mb-devel
+      run: docker exec -i dpdk dnf install -y ccache
         isa-l-devel jansson-devel libarchive-devel libatomic libbsd-devel
         libbpf-devel libfdt-devel libpcap-devel libxdp-devel ninja-build
         numactl-devel openssl-devel python3-pip python3-pyelftools
@@ -262,7 +262,7 @@ jobs:
     - name: Update
       run: docker exec -i dpdk dnf update -y || true
     - name: Install packages
-      run: docker exec -i dpdk dnf install -y ccache intel-ipsec-mb-devel
+      run: docker exec -i dpdk dnf install -y ccache
         isa-l-devel jansson-devel libarchive-devel libatomic libbsd-devel
         libbpf-devel libfdt-devel libpcap-devel libxdp-devel ninja-build
         numactl-devel openssl-devel python3-pip python3-pyelftools


### PR DESCRIPTION
The ipsec-mb version that is available through current package managers is 1.2.
This release moves the minimum required ipsec-mb version for ipsec-mb based SW PMDs to 1.4.
To compile these PMDs, a manual step is added to install ipsec-mb v1.4.