### PR TITLE
vhost: Fix the crash caused by accessing the released memory

### DIFF
--- a/lib/vhost/socket.c
+++ b/lib/vhost/socket.c
@@ -1125,6 +1125,8 @@ again:
 		if (vsocket->is_server) {
 			close(vsocket->socket_fd);
 			unlink(path);
+		} else if (vsocket->reconnect) {
+			vhost_user_remove_reconnect(vsocket);
 		}
 
 		pthread_mutex_destroy(&vsocket->conn_mutex);


### PR DESCRIPTION
The rte_vhost_driver_unregister() 、vhost_user_read_cb()、vhost_user_client_reconnect() can be called at the same time by 3 threads. when memory of vsocket is freed in rte_vhost_driver_unregister(), then vhost_user_read_cb() maybe add vsocket to reconn_list, the invalid memory of vsocket is accessed in vhost_user_client_reconnect(). 
The core trace is:
Program terminated with signal 11, Segmentation fault. 
The fix is to perform a delete operation again after releasing the memory