### PR TITLE
net/i40e: add gtp tunnel type in i40e_parse_tunneling_params

### DIFF
--- a/drivers/net/af_packet/rte_eth_af_packet.c
+++ b/drivers/net/af_packet/rte_eth_af_packet.c
@@ -769,7 +769,7 @@ rte_pmd_init_internals(struct rte_vdev_device *dev,
 
 #if defined(PACKET_FANOUT)
 	fanout_arg = (getpid() ^ (*internals)->if_index) & 0xffff;
-	fanout_arg |= (PACKET_FANOUT_HASH | PACKET_FANOUT_FLAG_DEFRAG) << 16;
+	fanout_arg |= PACKET_FANOUT_HASH << 16;
 #if defined(PACKET_FANOUT_FLAG_ROLLOVER)
 	fanout_arg |= PACKET_FANOUT_FLAG_ROLLOVER << 16;
 #endif

--- a/drivers/net/i40e/i40e_rxtx.c
+++ b/drivers/net/i40e/i40e_rxtx.c
@@ -273,6 +273,7 @@ i40e_parse_tunneling_params(uint64_t ol_flags,
 		/* for non UDP / GRE tunneling, set to 00b */
 		break;
 	case RTE_MBUF_F_TX_TUNNEL_VXLAN:
+	case RTE_MBUF_F_TX_TUNNEL_GTP:
 	case RTE_MBUF_F_TX_TUNNEL_GENEVE:
 		*cd_tunneling |= I40E_TXD_CTX_UDP_TUNNELING;
 		break;


### PR DESCRIPTION
i40e I40E_TX_OFFLOAD_MASK indicates that all tunnel types are supported, but gtp type is not considered in i40e_parse_tunneling_params(), tunneling parameter: L4TUNLEN is not set. Inner IP checksum calculation used the wrong L3 header offset, resulting in modifying the length field of the GTP header.