### PR TITLE
net/i40e: add gtp tunnel type in i40e_parse_tunneling_params

### DIFF
--- a/drivers/net/i40e/i40e_rxtx.c
+++ b/drivers/net/i40e/i40e_rxtx.c
@@ -274,6 +274,7 @@ i40e_parse_tunneling_params(uint64_t ol_flags,
 		break;
 	case RTE_MBUF_F_TX_TUNNEL_VXLAN:
 	case RTE_MBUF_F_TX_TUNNEL_GENEVE:
+	case RTE_MBUF_F_TX_TUNNEL_GTP:
 		*cd_tunneling |= I40E_TXD_CTX_UDP_TUNNELING;
 		break;
 	case RTE_MBUF_F_TX_TUNNEL_GRE:


### PR DESCRIPTION
i40e I40E_TX_OFFLOAD_MASK indicates that all tunnel types are supported, but gtp type is not considered in i40e_parse_tunneling_params(), tunneling parameter: L4TUNLEN is not set. Inner IP checksum calculation used the wrong L3 header offset, resulting in modifying the length field of the GTP header.