### PR TITLE
net/gve: Update Rx/Tx functions for RTE_PROC_SECONDARY

### DIFF
--- a/drivers/net/gve/gve_ethdev.c
+++ b/drivers/net/gve/gve_ethdev.c
@@ -1173,8 +1173,18 @@ gve_dev_init(struct rte_eth_dev *eth_dev)
 	rte_be32_t *db_bar;
 	int err;
 
-	if (rte_eal_process_type() != RTE_PROC_PRIMARY)
+	if (rte_eal_process_type() != RTE_PROC_PRIMARY) {
+		if (gve_is_gqi(priv)) {
+			gve_set_rx_function(eth_dev);
+			gve_set_tx_function(eth_dev);
+			eth_dev->dev_ops = &gve_eth_dev_ops;
+		} else {
+			gve_set_rx_function_dqo(eth_dev);
+			gve_set_tx_function_dqo(eth_dev);
+			eth_dev->dev_ops = &gve_eth_dev_ops_dqo;
+		}
 		return 0;
+	}
 
 	pci_dev = RTE_DEV_TO_PCI(eth_dev->device);
 


### PR DESCRIPTION
The RSS support for GVE allows multiple CPU cores to handle the rx/tx queues as pollers. This requires initializing the eth_dev_ops and updating the RX/TX functions for these pollers.


Acked-by: Rushil Gupta <rushilg@google.com>