### PR TITLE
usertools/devbind: support all possible values for unsafe_noiommu_mode flag

### DIFF
--- a/usertools/dpdk-devbind.py
+++ b/usertools/dpdk-devbind.py
@@ -490,7 +490,8 @@ def check_noiommu_mode():
 
     try:
         with open(filename, "r") as f:
-            if f.read(1) == "1":
+            value = f.read(1)
+            if value == "1" or value == "y" or value == "Y":
                 return
     except OSError as err:
         sys.exit(f"Error: failed to check unsafe noiommu mode - Cannot open {filename}: {err}")


### PR DESCRIPTION
This patch adds support for 'y' and 'Y' values when reading vfio-pci unsafe_noiommu_mode flag.
    
Possible values were taken from linux kernel
(sysfs__read_bool() in tools/lib/api/fs/fs.c)