### PR TITLE
Fix for C++ compilation inside of forced C extern headers

### DIFF
--- a/lib/eal/include/rte_bitops.h
+++ b/lib/eal/include/rte_bitops.h
@@ -1341,6 +1341,7 @@ rte_log2_u64(uint64_t v)
 #ifdef __cplusplus
 }
 
+extern "C++" {
 /*
  * Since C++ doesn't support generic selection (i.e., _Generic),
  * function overloading is used instead. Such functions must be
@@ -1502,7 +1503,7 @@ __RTE_BIT_OVERLOAD_3R(atomic_, test_and_clear,, bool, unsigned int, nr, int, mem
 __RTE_BIT_OVERLOAD_4R(atomic_, test_and_assign,, bool, unsigned int, nr, bool, value,
 	int, memory_order)
 #endif
-
+}
 #endif
 
 #endif /* _RTE_BITOPS_H_ */


### PR DESCRIPTION
If upper level API is defined as extern C on upper level and uses this header underneath it fails to compile in C++ app