### PR TITLE
dts: generate random capture_name per call (fix deterministic doc)

### DIFF
--- a/dts/framework/testbed_model/traffic_generator/capturing_traffic_generator.py
+++ b/dts/framework/testbed_model/traffic_generator/capturing_traffic_generator.py
@@ -70,7 +70,7 @@ class CapturingTrafficGenerator(TrafficGenerator):
         receive_port: Port,
         filter_config: PacketFilteringConfig,
         duration: float,
-        capture_name: str = _get_default_capture_name(),
+        capture_name: str = None,
     ) -> list[Packet]:
         """Send `packets` and capture received traffic.
 
@@ -103,6 +103,9 @@ class CapturingTrafficGenerator(TrafficGenerator):
             filter_config,
             duration,
         )
+
+        if capture_name is None:
+            capture_name = _get_default_capture_name()
 
         self._logger.debug(f"Received packets: {get_packet_summaries(received_packets)}")
         self._write_capture_from_packets(capture_name, received_packets)


### PR DESCRIPTION
Previously, `capture_name` defaulted to a "dynamic" value. This caused non-deterministic documentation (as reported in
https://bugs.dpdk.org/show_bug.cgi?id=1718) and could lead to overwriting capture files if the method was called multiple times within a single Python process.