### PR TITLE
eventdev/rxa: fix integer truncation in eth_dev_id validation

### DIFF
--- a/lib/eventdev/rte_event_eth_rx_adapter.c
+++ b/lib/eventdev/rte_event_eth_rx_adapter.c
@@ -3827,7 +3827,8 @@ handle_rxa_get_queue_conf(const char *cmd __rte_unused,
 {
 	uint8_t rx_adapter_id;
 	uint16_t rx_queue_id;
-	int eth_dev_id, ret = -1;
+	uint16_t eth_dev_id;
+	int ret = -1;
 	char *token, *l_params;
 	struct rte_event_eth_rx_adapter_queue_conf queue_conf;
 
@@ -3899,7 +3900,8 @@ handle_rxa_get_queue_stats(const char *cmd __rte_unused,
 {
 	uint8_t rx_adapter_id;
 	uint16_t rx_queue_id;
-	int eth_dev_id, ret = -1;
+	uint16_t eth_dev_id;
+	int ret = -1;
 	char *token, *l_params;
 	struct rte_event_eth_rx_adapter_queue_stats q_stats;
 
@@ -3970,7 +3972,8 @@ handle_rxa_queue_stats_reset(const char *cmd __rte_unused,
 {
 	uint8_t rx_adapter_id;
 	uint16_t rx_queue_id;
-	int eth_dev_id, ret = -1;
+	uint16_t eth_dev_id;
+	int ret = -1;
 	char *token, *l_params;
 
 	if (params == NULL || strlen(params) == 0 || !isdigit(*params))
@@ -4031,7 +4034,8 @@ handle_rxa_instance_get(const char *cmd __rte_unused,
 {
 	uint8_t instance_id;
 	uint16_t rx_queue_id;
-	int eth_dev_id, ret = -1;
+	uint16_t eth_dev_id;
+	int ret = -1;
 	char *token, *l_params;
 
 	if (params == NULL || strlen(params) == 0 || !isdigit(*params))


### PR DESCRIPTION
`eth_dev_id` is declared as `int` in `handle_rxa_get_queue_conf`,
`handle_rxa_get_queue_stats`, `handle_rxa_queue_stats_reset`, and
`handle_rxa_instance_get`, but is implicitly narrowed to `uint16_t` when
passed to `rte_eth_dev_is_valid_port` via
`RTE_EVENT_ETH_RX_ADAPTER_PORTID_VALID_OR_GOTO_ERR_RET`. This means
a value like 65535 + N passes validation as N, but is used as-is as
an array index, causing an out-of-bounds access and SIGSEGV.

To reproduce (requires `telemetry` enabled):
```
echo "/eventdev/rxa_queue_conf,0,65536,0" | \
  socat - UNIX-CONNECT:/var/run/dpdk/vpp/dpdk_telemetry.v2,type=5

```

Result:
```
SIGSEGV at handle_rxa_get_queue_conf + 0x34a, faulting address 0x50
```

Fix: Change `eth_dev_id` type from `int` to `uint16_t`.